### PR TITLE
Strip out _virtual_imports packages to support well known types

### DIFF
--- a/src/typescript_proto_library.bzl
+++ b/src/typescript_proto_library.bzl
@@ -100,6 +100,8 @@ def _get_outputs(target, ctx):
     js_outputs_es6 = []
     dts_outputs = []
     for src in target[ProtoInfo].direct_sources:
+        # workspace_root is empty for our local workspace, or external/other_workspace
+        # for @other_workspace//
         if ctx.label.workspace_root == "":
             file_name = src.basename[:-len(src.extension) - 1]
         else:

--- a/src/typescript_proto_library.bzl
+++ b/src/typescript_proto_library.bzl
@@ -24,10 +24,13 @@ def _proto_path(proto):
         path = path[len(root):]
     if path.startswith("/"):
         path = path[1:]
-    if path.startswith(ws):
+    if path.startswith(ws) and len(ws) > 0:
         path = path[len(ws):]
     if path.startswith("/"):
         path = path[1:]
+    if path.startswith("_virtual_imports/"):
+        path = path.split("/")[2:]
+        path = "/".join(path)
     return path
 
 def _get_protoc_inputs(target, ctx):
@@ -53,7 +56,7 @@ def _build_protoc_command(target, ctx):
 
     protoc_command += " --plugin=protoc-gen-ts=%s" % (ctx.executable._ts_protoc_gen.path)
 
-    protoc_output_dir = ctx.var["BINDIR"]
+    protoc_output_dir = ctx.bin_dir.path + "/" + ctx.label.workspace_root
     protoc_command += " --ts_out=service=grpc-web:%s" % (protoc_output_dir)
     protoc_command += " --js_out=import_style=commonjs,binary:%s" % (protoc_output_dir)
 
@@ -97,7 +100,11 @@ def _get_outputs(target, ctx):
     js_outputs_es6 = []
     dts_outputs = []
     for src in target[ProtoInfo].direct_sources:
-        file_name = src.basename[:-len(src.extension) - 1]
+        if ctx.label.workspace_root == "":
+            file_name = src.basename[:-len(src.extension) - 1]
+        else:
+            file_name = _proto_path(src)[:-len(src.extension) - 1]
+
         for f in ["_pb", "_pb_service"]:
             full_name = file_name + f
             output = ctx.actions.declare_file(full_name + ".js")

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -24,6 +24,8 @@ ts_library(
     deps = [
         "//test/proto:pizza_service_ts_proto",
         "//test/proto/common:delivery_person_ts_proto",
+        "@npm//google-protobuf",
+        "@npm//@types/google-protobuf",
         "@npm//@types/jasmine",
     ],
 )

--- a/test/commonjs_test.spec.ts
+++ b/test/commonjs_test.spec.ts
@@ -1,4 +1,5 @@
-import deliveryPersonPb = require('rules_typescript_proto/test/proto/common/delivery_person_pb');
+import {Timestamp} from 'google-protobuf/google/protobuf/timestamp_pb';
+import * as deliveryPersonPb from 'rules_typescript_proto/test/proto/common/delivery_person_pb';
 import {PizzaService} from 'rules_typescript_proto/test/proto/pizza_service_pb_service';
 
 describe('CommonJs', () => {
@@ -7,6 +8,9 @@ describe('CommonJs', () => {
 
     const person = new deliveryPersonPb.DeliveryPerson();
     person.setName('Doug');
+    const lastDeliveryTime = new Timestamp();
+    lastDeliveryTime.fromDate(new Date());
+    person.setLastDeliveryTime(lastDeliveryTime);
     expect(person).toBeDefined();
   });
 

--- a/test/proto/common/BUILD.bazel
+++ b/test/proto/common/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
         "delivery_person.proto",
     ],
     deps = [
+        "@com_google_protobuf//:timestamp_proto",
         ":pizza_proto",
     ],
 )

--- a/test/proto/common/delivery_person.proto
+++ b/test/proto/common/delivery_person.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package test.bazel.proto;
 
+import "google/protobuf/timestamp.proto";
 import "test/proto/common/pizza.proto";
 
 message DeliveryPerson {
@@ -16,4 +17,6 @@ message DeliveryPerson {
     string id = 3;
     int64 id_v2 = 4;
   }
+
+  google.protobuf.Timestamp last_delivery_time = 5;
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -15,6 +15,14 @@
     "noEmitOnError": true,
     "types": [
       "jasmine"
-    ]
+    ],
+    "baseUrl": "..",
+    "paths": {
+      "rules_typescript_proto/*": [
+        "*",
+        "bazel-bin/*"
+      ]
+    }
+
   }
 }


### PR DESCRIPTION
This is a first pass at working with the well known types and _virtual_imports. If this looks like a good approach, I can add some tests for it.

Fixes #4 