### PR TITLE
fix: rules_nodejs now uses :index.bzl

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 nodejs_binary(
     name = "change_import_style",


### PR DESCRIPTION
I think this also requires an update to 1.0.0 of `rules_nodejs`!