### PR TITLE
Update CI to only run on pushes to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevents duplicate CI runs for non-fork PRs.