### PR TITLE
Update rules_nodejs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,9 +15,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "e1a0d6eb40ec89f61a13a028e7113aa3630247253bcb1406281b627e44395145",
+    sha256 = "c97bf38546c220fa250ff2cc052c1a9eac977c662c1fc23eda797b0ce8e70a43",
     urls = [
-        "https://github.com/bazelbuild/rules_nodejs/releases/download/1.0.1/rules_nodejs-1.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_nodejs/releases/download/1.1.0/rules_nodejs-1.1.0.tar.gz",
     ],
 )
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/google-protobuf": "3.7.2",
     "@types/jasmine": "3.5.0",
     "clang-format": "1.3.0",
-    "husky": "4.0.9",
+    "husky": "4.0.10",
     "karma": "4.4.1",
     "karma-chrome-launcher": "3.1.0",
     "karma-firefox-launcher": "1.3.0",

--- a/src/typescript_proto_library.bzl
+++ b/src/typescript_proto_library.bzl
@@ -49,9 +49,9 @@ def _get_input_proto_names(target):
     return " ".join(proto_inputs)
 
 def _build_protoc_command(target, ctx):
-    protoc_command = "%s" % (ctx.file._protoc.path)
+    protoc_command = "%s" % (ctx.executable._protoc.path)
 
-    protoc_command += " --plugin=protoc-gen-ts=%s" % (ctx.files._ts_protoc_gen[1].path)
+    protoc_command += " --plugin=protoc-gen-ts=%s" % (ctx.executable._ts_protoc_gen.path)
 
     protoc_output_dir = ctx.var["BINDIR"]
     protoc_command += " --ts_out=service=grpc-web:%s" % (protoc_output_dir)
@@ -78,7 +78,7 @@ def _create_post_process_command(target, ctx, js_outputs, js_outputs_es6):
         ] if p])
         file_name = output.basename[:-len(output.extension) - 1]
 
-        convert_command = ctx.files._change_import_style[1].path
+        convert_command = ctx.executable._change_import_style.path
         convert_command += " --workspace_name {}".format(ctx.workspace_name)
         convert_command += " --input_base_path {}".format(file_path)
         convert_command += " --output_module_name {}".format(file_name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@ http-proxy@^1.13.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-husky@4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.0.9.tgz#ded9e4f957dd8358649330da84906b6bf2e367e9"
-  integrity sha512-zaH0INH9MZBH8smr6nPdzv7pjchOZPN/AKdhkuV4zut9SyF0+pUy1ZCBzhz2uPe7Cp75YzD92ewU2ytIZ0GjUQ==
+husky@4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.0.10.tgz#659b52c404d3163b943a73f6c1d454708c0226d8"
+  integrity sha512-Ptm4k2DqOwxeK/kzu5RaJmNRoGvESrgDXObFcZ8aJZcyXyMBHhM2FqZj6zYKdetadmP3wCwxEHCBuB9xGlRp8A==
   dependencies:
     chalk "^3.0.0"
     ci-info "^2.0.0"


### PR DESCRIPTION
Updates the rule to use ctx.executable instead of manually finding the entrypoint in ctx.files. This allows the rules_nodejs version to be updated.