### PR TITLE
Replaced ts_library with ts_project.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_typescript_proto_deps//@bazel/typescript:index.bzl", "ts_library")
+load("@rules_typescript_proto_deps//@bazel/typescript:index.bzl", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 nodejs_binary(
@@ -11,13 +11,14 @@ nodejs_binary(
     visibility = ["//visibility:public"],
 )
 
-ts_library(
+ts_project(
     name = "change_import_style_lib",
     srcs = [
         "change_import_style.ts",
     ],
+    tsconfig = "//:tsconfig.json",
     deps = [
-        "@rules_typescript_proto_deps//minimist", 
+        "@rules_typescript_proto_deps//minimist",
         "@rules_typescript_proto_deps//@types/node"
     ],
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "lib": [
       "dom",
@@ -10,7 +11,6 @@
       "es2015"
     ],
     "experimentalDecorators": true,
-    "types": [],
     "baseUrl": ".",
     "paths": {
       "rules_typescript_proto/*": [


### PR DESCRIPTION
The upstream `rules_typescript_proto` are performing similar changes where `ts_library` rules are being switched to `ts_project`.

This change also seems to address an issue we've been seeing since upgrading to Bazel 4.1.0.

Fixes #150 

(I attempted to make similar changes to the tests but I couldn't get the build to work as I was seeing `module not found` errors in the `common_js` test target - I'm not very familiar with the `jasmine_node_test` rule.)